### PR TITLE
RA exports discretize

### DIFF
--- a/examples/SDOF/SDOF_Model.jl
+++ b/examples/SDOF/SDOF_Model.jl
@@ -1,6 +1,7 @@
 # # Single degree-of-freedom
 
 using ReachabilityAnalysis, StructuralDynamicsODESolvers
+using ReachabilityAnalysis:discretize
 
 # ### Equations of motion
 


### PR DESCRIPTION
Fix Stacktrace:

```
julia> include("runall.jl")
Running examples...

 (1/5) Running single-degree-of-freedom (SDOF) model...

WARNING: both StructuralDynamicsODESolvers and ReachabilityAnalysis export "discretize"; uses of it in module Main must be qualified
ERROR: LoadError: LoadError: UndefVarError: discretize not defined
Stacktrace:
 [1] top-level scope
   @ C:\Users\Daniel\Documents\repos\github\SetPropagation-FEM-Examples\examples\SDOF\SDOF_Preliminaries.jl:43
 [2] include
   @ .\client.jl:444 [inlined]
 [3] main()
   @ Main C:\Users\Daniel\Documents\repos\github\SetPropagation-FEM-Examples\runall.jl:30
 [4] top-level scope
   @ C:\Users\Daniel\Documents\repos\github\SetPropagation-FEM-Examples\runall.jl:69
 [5] include(fname::String)
   @ Base.MainInclude .\client.jl:444
 [6] top-level scope
   @ REPL[2]:1
in expression starting at C:\Users\Daniel\Documents\repos\github\SetPropagation-FEM-Examples\examples\SDOF\SDOF_Preliminaries.jl:43
in expression starting at C:\Users\Daniel\Documents\repos\github\SetPropagation-FEM-Examples\runall.jl:69
```